### PR TITLE
Add dedicated install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install dependencies via Homebrew
+packages=(
+  starship
+  fzf
+  eza
+  bat
+  zoxide
+  tmux
+  neovim
+  stow
+)
+
+if command -v brew >/dev/null 2>&1; then
+  brew install "${packages[@]}"
+else
+  echo "Homebrew not installed. Skipping brew package installation."
+fi
+
+# Install oh-my-zsh
+if [ ! -d "$HOME/.oh-my-zsh" ]; then
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+fi
+
+# Install oh-my-zsh plugins
+plugins_dir="$HOME/.oh-my-zsh/custom/plugins"
+declare -A plugins=(
+  ["https://github.com/zsh-users/zsh-autosuggestions.git"]="$plugins_dir/zsh-autosuggestions"
+  ["https://github.com/zsh-users/zsh-syntax-highlighting.git"]="$plugins_dir/zsh-syntax-highlighting"
+  ["https://github.com/remcohaszing/zsh-node-bin.git"]="$plugins_dir/node-bin"
+  ["https://github.com/fdellwing/zsh-bat.git"]="$plugins_dir/zsh-bat"
+  ["https://github.com/lukechilds/zsh-nvm"]="$plugins_dir/zsh-nvm"
+)
+
+for repo in "${!plugins[@]}"; do
+  dest="${plugins[$repo]}"
+  if [ ! -d "$dest/.git" ]; then
+    git clone "$repo" "$dest"
+  fi
+done
+
+# Install Catppuccin Tmux theme
+catppuccin_dir="$HOME/.config/tmux/plugins/catppuccin/tmux"
+if [ ! -d "$catppuccin_dir/.git" ]; then
+  git clone -b v2.1.3 https://github.com/catppuccin/tmux.git "$catppuccin_dir"
+fi
+
+# Install tpm (Tmux Plugin Manager)
+tpm="$HOME/.tmux/plugins/tpm"
+if [ ! -d "$tpm/.git" ]; then
+  git clone https://github.com/tmux-plugins/tpm "$tpm"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,31 +1,10 @@
-# Brew installation
-brew install starship fzf eza bat zoxide tmux neovim stow
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Install oh-my-zsh
-[ -d "$HOME/.oh-my-zsh" ] || sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+# Run dependency installation if install.sh exists
+if [[ -f "$(dirname "$0")/install.sh" ]]; then
+  "$(dirname "$0")/install.sh"
+fi
 
-# Install oh-my-zsh plugins
-plugins="$HOME/.oh-my-zsh/custom/plugins"
-typeset -A plugins=(
-  "https://github.com/zsh-users/zsh-autosuggestions.git" "$plugins/zsh-autosuggestions"
-  "https://github.com/zsh-users/zsh-syntax-highlighting.git" "$plugins/zsh-syntax-highlighting"
-  "https://github.com/remcohaszing/zsh-node-bin.git" "$plugins/node-bin"
-  "https://github.com/fdellwing/zsh-bat.git" "$plugins/zsh-bat"
-  "https://github.com/lukechilds/zsh-nvm" "$plugins/zsh-nvm"
-)
-
-for repo dest in ${(kv)plugins}; do
-  [[ -d "$dest/.git" ]] || git clone "$repo" "$dest"
-done
-
-# Install script for Catppuccin Tmux 
-dir=$HOME/.config/tmux/plugins/catppuccin/tmux
-[ -d "$dir/.git" ] || git clone -b v2.1.3 https://github.com/catppuccin/tmux.git "$dir"
-
-
-# Install tpm (Tmux Plugin Manager)
-tpm=$HOME/.tmux/plugins/tpm
-[ -d "$tpm/.git" ] || git clone https://github.com/tmux-plugins/tpm "$tpm"
-
-# Apply simlinks 
-stow -t $HOME -d "$HOME/dotfiles" --ignore "README.md" --ignore "setup.sh" .
+# Apply symlinks
+stow -t "$HOME" -d "$HOME/dotfiles" --ignore "README.md" --ignore "setup.sh" .


### PR DESCRIPTION
## Summary
- add an `install.sh` script to handle package and plugin installation
- simplify `setup.sh` to delegate installation and just apply symlinks

## Testing
- `shellcheck setup.sh install.sh`
- `bash -n setup.sh install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6849ec8d081c832ba0d55768c2fc17a0