### PR TITLE
feat: enable inline image rendering in markdown files

### DIFF
--- a/.config/nvim/lua/mappings.lua
+++ b/.config/nvim/lua/mappings.lua
@@ -49,3 +49,5 @@ map("n", "<leader>l", ":TestLast<cr>", { silent = true })
 map("n", "<leader>ih", function()
   vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
 end, { desc = "Toggle inlay hints" })
+
+map("n", "<leader>rc", ":source $MYVIMRC<cr>", { desc = "Reload config" })

--- a/.config/nvim/lua/options.lua
+++ b/.config/nvim/lua/options.lua
@@ -14,6 +14,14 @@ vim.api.nvim_create_autocmd("BufReadPost", {
   end,
 })
 
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "markdown",
+  callback = function()
+    vim.opt_local.number = false
+    vim.opt_local.relativenumber = false
+  end,
+})
+
 vim.api.nvim_create_autocmd("BufDelete", {
   callback = function()
     local bufs = vim.t.bufs

--- a/.config/nvim/lua/options.lua
+++ b/.config/nvim/lua/options.lua
@@ -14,9 +14,12 @@ vim.api.nvim_create_autocmd("BufReadPost", {
   end,
 })
 
-vim.api.nvim_create_autocmd("FileType", {
-  pattern = "markdown",
-  callback = function()
+vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "FileType" }, {
+  callback = function(ev)
+    if vim.bo[ev.buf].filetype ~= "markdown" then
+      return
+    end
+
     vim.opt_local.number = false
     vim.opt_local.relativenumber = false
   end,

--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -239,6 +239,7 @@ return {
           style = "above_cursor",
         },
       },
+      image = { enabled = true },
       bigfile = { enabled = true },
     },
   },
@@ -341,6 +342,10 @@ return {
       heading = { position = "inline" },
       sign = { enabled = false },
       file_types = { "markdown" },
+      image = {
+        enabled = true,
+        provider = "snacks",
+      },
     },
     ft = { "markdown" },
     config = function(_, opts)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Dotfiles
-<img width="1483" alt="Screenshot 2025-06-12 at 1 57 31 PM" src="https://github.com/user-attachments/assets/d848419f-9587-4760-94c5-6d2a84d5ab70" />
+![Screenshot 2025-06-12 at 1 57 31 PM](https://github.com/user-attachments/assets/d848419f-9587-4760-94c5-6d2a84d5ab70)
 
 This repository contains configuration files for customizing my command line environment.
 It includes settings for:

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ echo > "$HOME/.hushlogin"
 command -v brew >/dev/null || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Brew installation
-brew install opencode starship fzf git-graph eza bat zoxide tmux ripgrep fd neovim stow pngpaste tree-sitter-cli
+brew install opencode starship fzf git-graph eza bat zoxide tmux ripgrep fd neovim stow pngpaste tree-sitter-cli imagemagick
 
 # Install oh-my-zsh
 [ -d "$HOME/.oh-my-zsh" ] || sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"


### PR DESCRIPTION
## Summary

- **Enabled `Snacks.image`** in `snacks.nvim` opts to activate the Kitty graphics protocol image backend (supported by Ghostty)
- **Configured `render-markdown.nvim`** to use `snacks` as the image provider, allowing inline image rendering in markdown buffers
- **Converted README `<img>` tag to standard markdown syntax** (`![alt](url)`) for better compatibility with render-markdown.nvim
- **Disabled line numbers for markdown files** via a `FileType` autocmd in `options.lua` for a cleaner reading experience
- **Added `imagemagick` to `setup.sh`** brew install list, which is required by snacks.nvim for image processing