### PR TITLE
feat: configure default agent and model settings for opencode

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -8,5 +8,15 @@
       "type": "local",
       "command": ["npx", "-y", "chrome-devtools-mcp@latest"]
     }
+  },
+  "default_agent": "plan",
+  "agent": {
+    "plan": {
+      "model": "anthropic/claude-opus-4-6",
+      "variant": "high"
+    },
+    "build": {
+      "model": "anthropic/claude-sonnet-4-6"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Set `plan` as the default agent using `claude-opus-4-6` (high variant)
- Configure `build` agent to use `claude-sonnet-4-6`