### PR TITLE
chore: update fzf default options

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -16,19 +16,13 @@ zstyle ':omz:update' mode auto
 zstyle ':omz:plugins:eza' 'dirs-first' yes
 zstyle ':omz:plugins:eza' 'icons' yes
 
-export FZF_DEFAULT_OPTS='--preview "bat --color=always --line-range :500 {}"'
-
-_fzf_comprun() {
-  local command=$1
-  shift
-
-  case "$command" in
-    cd)           fzf --preview 'eza --tree --color=always {} | head -200'   "$@" ;;
-    export|unset) fzf --preview "eval 'echo \$'{}"                           "$@" ;;
-    ssh)          fzf --preview 'dig {}'                                     "$@" ;;
-    *)            fzf --preview 'bat -n --color=always {}'                   "$@" ;;
-  esac
-}
+export FZF_DEFAULT_OPTS=$'
+  --preview-window=hidden
+  --color=bg+:#313244,bg:#1e1e2e,spinner:#f5e0dc,hl:#f38ba8
+  --color=fg:#cdd6f4,header:#f38ba8,info:#cba6f7,pointer:#f5e0dc
+  --color=marker:#b4befe,fg+:#cdd6f4,prompt:#cba6f7,hl+:#f38ba8
+  --color=border:#313244,label:#cdd6f4
+'
 
 alias wstorm='open -na "WebStorm.app" --args'
 alias vim="nvim"


### PR DESCRIPTION
## Summary
- simplify `.zshrc` by removing the custom `_fzf_comprun` function overrides
- switch `FZF_DEFAULT_OPTS` to a multiline Catppuccin Mocha color configuration
- default fzf previews to hidden for a cleaner initial picker UI